### PR TITLE
Better sniffing of content type.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function (express) {
   express.response.send = function(code, body) {
     body == null && (body=code, code=null)
 
-    if (this.get('Content-Type') === 'application/json' && typeof body === 'string')
+    if ((this.get('Content-Type') || "").indexOf('application/json') > -1 && typeof body === 'string')
       body = body.replace(/</g, '\\u003c')
 
     return code

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "html"
   ],
   "author": "Nadav Ivgi <nadav@bitrated.com>",
+  "contributors": [{
+    "name": "Tyler Waters",
+    "email": "tyler.waters@gmail.com"
+  }],
   "license": "MIT"
 }


### PR DESCRIPTION
In the current version of express, the charset is appended to the content
type. Update the sniffing to check for the presence of `application/json`
and not the exact string.

Fixes #1
